### PR TITLE
removed LibStub support

### DIFF
--- a/DragonNextLocation.txt
+++ b/DragonNextLocation.txt
@@ -1,10 +1,10 @@
 ## Title: Dragon Next Location
 ## Description: Show the next location of Elsweyr dragons
-## Version: 1.1.1
+## Version: 1.1.2
 ## Author: bulton-fr
-## APIVersion: 100029
+## APIVersion: 100031 100032
 ## SavedVariables: DragonNextLocationSavedVariables
-## DependsOn: LibDragonWorldEvent LibMapPins-1.0
+## DependsOn: LibDragonWorldEvent LibMapPins-1.0>=10022
 
 Initialise.lua
 Events.lua

--- a/Initialise.lua
+++ b/Initialise.lua
@@ -5,10 +5,6 @@ DragonNextLocation.ready      = false
 DragonNextLocation.savedVars  = nil
 DragonNextLocation.libMapPins = LibMapPins
 
-if LibMapPins == nil and LibStub then
-    DragonNextLocation.libMapPins = LibStub("LibMapPins-1.0")
-end
-
 --[[
 -- Addon initialiser
 --]]


### PR DESCRIPTION
```
DragonNextLocation.libMapPins = LibMapPins
if LibMapPins == nil and LibStub then
```
DragonNextLocation.libMapPins will never be nil, because it's using the global call for LibMapPins